### PR TITLE
escape JSON content

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class LogStream extends Writable {
         '${content.msg}',
         '${content.pid}',
         '${content.time}',
-        '${JSON.stringify(content)}'
+        '${LogStream.escapeString(JSON.stringify(content))}'
       );
     `)
   }
@@ -73,6 +73,10 @@ class LogStream extends Writable {
   // end (cb) {
   //   this.end(cb)
   // }
+
+  static escapeString (str) {
+    return str.split('\'').join('\'\'')
+  }
 }
 
 module.exports = (options = {}) => {


### PR DESCRIPTION
Single quotes in the JSON content would allow SQL injections or just causes errors. This patch replaces one single quotes with two single quotes.